### PR TITLE
add gnome-icon-theme dependency

### DIFF
--- a/zathura.rb
+++ b/zathura.rb
@@ -14,6 +14,7 @@ class Zathura < Formula
   depends_on "libmagic"
   depends_on "gettext"
   depends_on "girara"
+  depends_on "gnome-icon-theme"
 
   def install
     # Set Homebrew prefix


### PR DESCRIPTION
for missing icons in the print dialog.

Before:
![before](https://cloud.githubusercontent.com/assets/9107883/9541795/db64297e-4d6b-11e5-8109-9e693f8c3d75.png)

After:
![after](https://cloud.githubusercontent.com/assets/9107883/9541794/db4730c6-4d6b-11e5-8448-6616b9815520.png)
